### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ client.onAny(event => {
 
 ## `LaplaceEvent`
 
-`LaplaceEvent` is the core type of the event bridge system, representing events exchanged between LAPLACE Chat and connected clients. Each event contains standardized data for various chat streams from Biliibli Live.
+`LaplaceEvent` is the core type of the event bridge system, representing events exchanged between LAPLACE Chat and connected clients. Each event contains standardized data for various chat streams from Bilibili Live.
 
 All events share a common `type` field that identifies the event category and additional fields specific to each event type.
 


### PR DESCRIPTION
## Summary
- fix the spelling of Bilibili in `README.md`

## Testing
- `git log -1 --stat`