### PR TITLE
docs: design for SDK /info room discovery

### DIFF
--- a/.changeset/sdk-info-room-discovery.md
+++ b/.changeset/sdk-info-room-discovery.md
@@ -1,0 +1,5 @@
+---
+"@laplace.live/event-bridge-sdk": minor
+---
+
+Add `/info` room discovery: a standalone `fetchInfo({ url, token })` and a `client.getInfo()` method that fetch the LAPLACE Event Fetcher `/info` endpoint and return the configured rooms plus instance metadata (`FetcherInfo` / `FetcherRoom`). Returns `null` when discovery is unsupported (a plain Event Bridge server or an older fetcher), so callers can fall back to manual entry. No active connection required.

--- a/docs/superpowers/plans/2026-06-02-sdk-info-room-discovery.md
+++ b/docs/superpowers/plans/2026-06-02-sdk-info-room-discovery.md
@@ -89,7 +89,7 @@ describe('fetchInfo', () => {
   })
 
   test('derives an http URL from a ws URL and appends /info', async () => {
-    const spy = jest.fn(async () => okResponse(sampleInfo))
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
     globalThis.fetch = spy as unknown as typeof fetch
 
     await fetchInfo({ url: 'ws://localhost:9696' })
@@ -99,7 +99,7 @@ describe('fetchInfo', () => {
   })
 
   test('derives an https URL from a wss URL', async () => {
-    const spy = jest.fn(async () => okResponse(sampleInfo))
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
     globalThis.fetch = spy as unknown as typeof fetch
 
     await fetchInfo({ url: 'wss://event-fetcher.laplace.cn' })
@@ -108,7 +108,7 @@ describe('fetchInfo', () => {
   })
 
   test('does not double up a trailing slash on the base URL', async () => {
-    const spy = jest.fn(async () => okResponse(sampleInfo))
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
     globalThis.fetch = spy as unknown as typeof fetch
 
     await fetchInfo({ url: 'ws://localhost:9696/' })
@@ -116,8 +116,26 @@ describe('fetchInfo', () => {
     expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
   })
 
+  test('passes through an http URL unchanged', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'http://localhost:9696' })
+
+    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+  })
+
+  test('preserves a sub-path for reverse-proxied fetchers', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'wss://example.com/lef/' })
+
+    expect(spy.mock.calls[0]![0]).toBe('https://example.com/lef/info')
+  })
+
   test('sends an Authorization bearer header when a token is provided', async () => {
-    const spy = jest.fn(async () => okResponse(sampleInfo))
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
     globalThis.fetch = spy as unknown as typeof fetch
 
     await fetchInfo({ url: 'ws://localhost:9696', token: 'secret' })
@@ -127,7 +145,7 @@ describe('fetchInfo', () => {
   })
 
   test('omits the Authorization header when no token is provided', async () => {
-    const spy = jest.fn(async () => okResponse(sampleInfo))
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
     globalThis.fetch = spy as unknown as typeof fetch
 
     await fetchInfo({ url: 'ws://localhost:9696' })
@@ -287,10 +305,12 @@ Replace with (same code, then the two module-level functions appended after the 
 }
 
 /**
- * Convert a ws/wss URL to its http/https origin (preserving host and port) so we
- * can reach HTTP endpoints like `/info`. http(s) URLs pass through; a bare host
- * with no scheme defaults to http (or https when it targets port 443). Any
- * trailing slash is stripped so callers can append a path.
+ * Convert a ws/wss URL to the http/https URL of the same endpoint so we can
+ * reach HTTP routes like `/info`. Swaps the scheme (wss→https, ws→http) and
+ * preserves host, port, and any path (so a fetcher reverse-proxied under a
+ * sub-path still resolves). http(s) URLs pass through; a bare host with no
+ * scheme defaults to http, or https when it targets port 443. Any trailing
+ * slash is stripped so callers can append a path.
  */
 function wsToHttp(url: string): string {
   let httpUrl: string
@@ -301,7 +321,7 @@ function wsToHttp(url: string): string {
   } else if (url.startsWith('http://') || url.startsWith('https://')) {
     httpUrl = url
   } else {
-    httpUrl = `${url.includes(':443') ? 'https' : 'http'}://${url}`
+    httpUrl = `${/:443(\/|$)/.test(url) ? 'https' : 'http'}://${url}`
   }
   return httpUrl.replace(/\/+$/, '')
 }
@@ -357,13 +377,13 @@ export async function fetchInfo(options: FetchInfoOptions): Promise<FetcherInfo 
 - [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `cd packages/sdk && bun test -t fetchInfo`
-Expected: PASS — 13 tests pass, 0 fail.
+Expected: PASS — 15 tests pass, 0 fail.
 
-- [ ] **Step 6: Verify the public types still typecheck**
+- [ ] **Step 6: Verify the public types and tests typecheck**
 
-Run:
+Run (both files — `noUncheckedIndexedAccess` means mocks inspected via `.mock.calls[0]` need typed params, which the tests above provide):
 ```bash
-cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts
+cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts index.test.ts
 ```
 Expected: no output, exit 0.
 
@@ -403,7 +423,7 @@ describe('client.getInfo', () => {
       websocketClients: 0,
       rooms: [],
     }
-    const spy = jest.fn(async () =>
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) =>
       new Response(JSON.stringify({ success: true, status: 200, data }), { status: 200 })
     )
     globalThis.fetch = spy as unknown as typeof fetch
@@ -478,9 +498,9 @@ Expected: PASS — 1 test passes, 0 fail.
 
 Run:
 ```bash
-cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts && bun test
+cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts index.test.ts && bun test
 ```
-Expected: tsc — no output, exit 0; `bun test` — all tests pass (the pre-existing 5 + 13 fetchInfo + 1 getInfo = 19), 0 fail. (Full run takes ~30s due to the reconnection test.)
+Expected: tsc — no output, exit 0; `bun test` — all tests pass (the pre-existing 5 + 15 fetchInfo + 1 getInfo = 21), 0 fail. (Full run takes ~30s due to the reconnection test.)
 
 - [ ] **Step 6: Commit**
 
@@ -664,7 +684,7 @@ git commit -m "chore(sdk): add changeset for /info room discovery"
   ```bash
   cd packages/sdk && bun test && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts example.ts index.test.ts
   ```
-  Expected: `bun test` → all pass (19 tests), 0 fail; `tsc` → no output, exit 0.
+  Expected: `bun test` → all pass (21 tests), 0 fail; `tsc` → no output, exit 0.
 - [ ] `git log --oneline -4` shows the four commits (feat fetchInfo, feat getInfo, docs, changeset).
 
 ---

--- a/docs/superpowers/plans/2026-06-02-sdk-info-room-discovery.md
+++ b/docs/superpowers/plans/2026-06-02-sdk-info-room-discovery.md
@@ -1,0 +1,675 @@
+# SDK `/info` Room Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class, typed `/info` room discovery to `@laplace.live/event-bridge-sdk` so consumers stop hand-rolling the types, ws→http URL derivation, and fetch/fallback.
+
+**Architecture:** A standalone exported `fetchInfo({ url, token, signal })` does a `GET <http-url>/info` (deriving the HTTP URL from the ws/wss URL via an internal `wsToHttp` helper), returns the unwrapped `data` payload as `FetcherInfo`, and returns `null` on any failure (never throws). A thin `client.getInfo()` method delegates to it using the client's configured `url`/`token` — no active connection required.
+
+**Tech Stack:** TypeScript, Bun runtime, `bun:test`, Changesets. The SDK is a single module (`packages/sdk/index.ts`) with zero runtime dependencies; `fetch`/`Response`/`AbortSignal` are standard globals in all target runtimes.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-sdk-info-room-discovery-design.md`
+
+---
+
+## File Structure
+
+All work is in the `packages/sdk` package. No new files in the package source (the SDK is intentionally a single module).
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `packages/sdk/index.ts` | The entire SDK surface | Add `FetcherRoom`/`FetcherInfo`/`FetchInfoOptions` (exported) + `FetcherInfoResponse`/`wsToHttp` (internal) + `fetchInfo()` (exported) + `getInfo()` method |
+| `packages/sdk/index.test.ts` | Bun tests | Append `describe('fetchInfo')` and `describe('client.getInfo')` blocks; extend the `./index` import |
+| `packages/sdk/README.md` | Public docs | Add `getInfo` to the method list + a "Room Discovery" section |
+| `packages/sdk/example.ts` | Runnable example | Add a discovery snippet before `connect()` |
+| `.changeset/sdk-info-room-discovery.md` | Release note | New `minor` changeset |
+
+## Conventions & commands (read once)
+
+- **Run tests from the package dir.** `bun test` runs the whole suite, but it includes a ~28s reconnection test. During iteration, filter by name:
+  - `cd packages/sdk && bun test -t fetchInfo`
+  - `cd packages/sdk && bun test -t getInfo`
+  - Full run at the end: `cd packages/sdk && bun test`
+- **Type gate for the public API.** `tsc -p tsconfig.json` is permanently red because of the unrelated `references/` folder (a copy of the server with missing deps). Do NOT use it. Instead typecheck the library file in isolation with the project's flags:
+  ```bash
+  cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts
+  ```
+  Expected: no output, exit 0.
+- **Style notes that will bite you:** `strict` + `noUncheckedIndexedAccess` are on, so array access is `T | undefined` — the tests use `!` (e.g. `spy.mock.calls[0]![0]`). `verbatimModuleSyntax` is on — import values normally, but any type-only import must use `import type`.
+
+---
+
+## Task 1: `fetchInfo()` + types + `wsToHttp()`
+
+**Files:**
+- Modify: `packages/sdk/index.ts` (add types after `ConnectionOptions` at line 64; append functions after the class at line 469)
+- Test: `packages/sdk/index.test.ts` (extend import on line 3; append a `describe` block after line 228)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/sdk/index.test.ts`, change the import on line 3 from:
+
+```ts
+import { ConnectionState, LaplaceEventBridgeClient } from './index'
+```
+
+to:
+
+```ts
+import { ConnectionState, fetchInfo, LaplaceEventBridgeClient } from './index'
+```
+
+Then append this block to the end of the file (after the closing `})` of the top-level `describe('LaplaceEventBridgeClient', …)`):
+
+```ts
+describe('fetchInfo', () => {
+  const realFetch = globalThis.fetch
+
+  // Minimal valid `/info` payload — the `data` object fetchInfo returns.
+  const sampleInfo = {
+    version: '4.0.20',
+    uptime: '2 hours ago',
+    connectedAt: 1717200000000,
+    websocketBridge: true,
+    websocketClients: 3,
+    rooms: [
+      { status: 0, uid: 2132180406, roomId: 25034104, shortRoomId: 0, username: '明前奶绿' },
+      { status: 404, uid: 0, roomId: 456117, shortRoomId: 0, username: null },
+    ],
+  }
+
+  const okResponse = (data: unknown) =>
+    new Response(JSON.stringify({ success: true, status: 200, data }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  test('derives an http URL from a ws URL and appends /info', async () => {
+    const spy = jest.fn(async () => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696' })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+  })
+
+  test('derives an https URL from a wss URL', async () => {
+    const spy = jest.fn(async () => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'wss://event-fetcher.laplace.cn' })
+
+    expect(spy.mock.calls[0]![0]).toBe('https://event-fetcher.laplace.cn/info')
+  })
+
+  test('does not double up a trailing slash on the base URL', async () => {
+    const spy = jest.fn(async () => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696/' })
+
+    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+  })
+
+  test('sends an Authorization bearer header when a token is provided', async () => {
+    const spy = jest.fn(async () => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696', token: 'secret' })
+
+    const init = spy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer secret')
+  })
+
+  test('omits the Authorization header when no token is provided', async () => {
+    const spy = jest.fn(async () => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696' })
+
+    const init = spy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>).authorization).toBeUndefined()
+  })
+
+  test('returns the data payload on success', async () => {
+    globalThis.fetch = (async () => okResponse(sampleInfo)) as unknown as typeof fetch
+
+    const info = await fetchInfo({ url: 'ws://localhost:9696' })
+
+    expect(info).toEqual(sampleInfo)
+    expect(info?.rooms).toHaveLength(2)
+  })
+
+  test('returns null without fetching when url is empty', async () => {
+    const spy = jest.fn()
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    const info = await fetchInfo({ url: '' })
+
+    expect(info).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('returns null on a non-ok response (e.g. 403)', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 403 })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null when the envelope success flag is false', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ success: false, status: 403, message: 'Unauthorized' }), {
+        status: 200,
+      })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null when rooms is not an array', async () => {
+    globalThis.fetch = (async () => okResponse({ ...sampleInfo, rooms: undefined })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null on a network error', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null on invalid JSON', async () => {
+    globalThis.fetch = (async () => new Response('not json', { status: 200 })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null when the signal is already aborted', async () => {
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException('Aborted', 'AbortError')
+      }
+      return okResponse(sampleInfo)
+    }) as unknown as typeof fetch
+
+    const controller = new AbortController()
+    controller.abort()
+
+    expect(await fetchInfo({ url: 'ws://localhost:9696', signal: controller.signal })).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/sdk && bun test -t fetchInfo`
+Expected: FAIL — the test file fails to load because `./index` does not yet export `fetchInfo` (Bun reports a missing-export error like `export 'fetchInfo' not found in './index'`).
+
+- [ ] **Step 3: Add the types**
+
+In `packages/sdk/index.ts`, find (lines 62-66):
+
+```ts
+  pingTimeout?: number
+}
+
+export class LaplaceEventBridgeClient {
+```
+
+Replace with:
+
+```ts
+  pingTimeout?: number
+}
+
+export interface FetcherRoom {
+  /** 0 when the room was resolved, otherwise an error code (e.g. 404). */
+  status: number
+  uid: number
+  /** Canonical room id. Matches the `origin` field on incoming events. */
+  roomId: number
+  shortRoomId: number
+  username: string | null
+}
+
+export interface FetcherInfo {
+  version: string
+  uptime: string
+  connectedAt: number
+  websocketBridge: boolean
+  websocketClients: number
+  rooms: FetcherRoom[]
+}
+
+export interface FetchInfoOptions {
+  /** Same ws/wss URL style as ConnectionOptions.url, e.g. 'ws://localhost:9696'. */
+  url: string
+  /** Auth token; sent as `Authorization: Bearer <token>` when present. */
+  token?: string
+  /** Optional AbortSignal for cancellation (e.g. a modal closing). */
+  signal?: AbortSignal
+}
+
+/** The `/info` response envelope. Internal — callers receive the unwrapped `data` (FetcherInfo). */
+interface FetcherInfoResponse {
+  success: boolean
+  status: number
+  data: FetcherInfo
+}
+
+export class LaplaceEventBridgeClient {
+```
+
+- [ ] **Step 4: Add `wsToHttp()` and `fetchInfo()`**
+
+In `packages/sdk/index.ts`, find the end of the class (lines 463-469):
+
+```ts
+  private stopPingMonitoring(): void {
+    if (this.pingMonitorTimer) {
+      clearInterval(this.pingMonitorTimer)
+      this.pingMonitorTimer = null
+    }
+  }
+}
+```
+
+Replace with (same code, then the two module-level functions appended after the class):
+
+```ts
+  private stopPingMonitoring(): void {
+    if (this.pingMonitorTimer) {
+      clearInterval(this.pingMonitorTimer)
+      this.pingMonitorTimer = null
+    }
+  }
+}
+
+/**
+ * Convert a ws/wss URL to its http/https origin (preserving host and port) so we
+ * can reach HTTP endpoints like `/info`. http(s) URLs pass through; a bare host
+ * with no scheme defaults to http (or https when it targets port 443). Any
+ * trailing slash is stripped so callers can append a path.
+ */
+function wsToHttp(url: string): string {
+  let httpUrl: string
+  if (url.startsWith('wss://')) {
+    httpUrl = `https://${url.slice('wss://'.length)}`
+  } else if (url.startsWith('ws://')) {
+    httpUrl = `http://${url.slice('ws://'.length)}`
+  } else if (url.startsWith('http://') || url.startsWith('https://')) {
+    httpUrl = url
+  } else {
+    httpUrl = `${url.includes(':443') ? 'https' : 'http'}://${url}`
+  }
+  return httpUrl.replace(/\/+$/, '')
+}
+
+/**
+ * Fetch instance/room info from a LAPLACE Event Fetcher `/info` endpoint.
+ *
+ * Returns `null` (never throws) whenever the info cannot be determined: an old
+ * fetcher without `/info`, a plain Event Bridge server, an aborted request, or
+ * any network/HTTP/parse error. Callers should treat `null` as "not supported"
+ * and fall back to manual entry.
+ *
+ * @example
+ * const info = await fetchInfo({ url: 'ws://localhost:9696', token })
+ * info?.rooms.forEach(room => console.log(room.roomId, room.username))
+ */
+export async function fetchInfo(options: FetchInfoOptions): Promise<FetcherInfo | null> {
+  const { url, token, signal } = options
+  if (!url) {
+    return null
+  }
+
+  try {
+    const headers: Record<string, string> = {}
+    if (token) {
+      headers.authorization = `Bearer ${token}`
+    }
+
+    const response = await fetch(`${wsToHttp(url)}/info`, {
+      method: 'GET',
+      headers,
+      signal,
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const json = (await response.json()) as FetcherInfoResponse
+    if (!json?.success || !Array.isArray(json?.data?.rooms)) {
+      return null
+    }
+
+    return json.data
+  } catch {
+    // Silent fallback: old fetcher without /info, plain Event Bridge server,
+    // aborted request, network failure, or a non-JSON response.
+    return null
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd packages/sdk && bun test -t fetchInfo`
+Expected: PASS — 13 tests pass, 0 fail.
+
+- [ ] **Step 6: Verify the public types still typecheck**
+
+Run:
+```bash
+cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/index.ts packages/sdk/index.test.ts
+git commit -m "feat(sdk): add fetchInfo() for /info room discovery"
+```
+
+---
+
+## Task 2: `client.getInfo()` method
+
+**Files:**
+- Modify: `packages/sdk/index.ts` (insert method between `getClientId` at line 346 and `send` at line 348)
+- Test: `packages/sdk/index.test.ts` (append a second `describe` block)
+
+- [ ] **Step 1: Write the failing test**
+
+Append this block to the end of `packages/sdk/index.test.ts` (after the `describe('fetchInfo', …)` block from Task 1). No import change is needed — `LaplaceEventBridgeClient` is already imported.
+
+```ts
+describe('client.getInfo', () => {
+  const realFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  test('fetches /info using the client url and token without connecting', async () => {
+    const data = {
+      version: '4.0.20',
+      uptime: '',
+      connectedAt: 0,
+      websocketBridge: true,
+      websocketClients: 0,
+      rooms: [],
+    }
+    const spy = jest.fn(async () =>
+      new Response(JSON.stringify({ success: true, status: 200, data }), { status: 200 })
+    )
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    const client = new LaplaceEventBridgeClient({ url: 'wss://example.com', token: 'tok' })
+    const info = await client.getInfo()
+
+    expect(spy.mock.calls[0]![0]).toBe('https://example.com/info')
+    const init = spy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer tok')
+    expect(info?.rooms).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/sdk && bun test -t getInfo`
+Expected: FAIL — `client.getInfo is not a function`.
+
+- [ ] **Step 3: Add the `getInfo` method**
+
+In `packages/sdk/index.ts`, find (lines 341-351):
+
+```ts
+  /**
+   * Get the client ID assigned by the bridge
+   */
+  public getClientId(): string | null {
+    return this.clientId
+  }
+
+  /**
+   * Send an event to the bridge
+   * @param event The event to send
+   */
+```
+
+Replace with:
+
+```ts
+  /**
+   * Get the client ID assigned by the bridge
+   */
+  public getClientId(): string | null {
+    return this.clientId
+  }
+
+  /**
+   * Fetch `/info` (configured rooms + instance metadata) from the connected
+   * LAPLACE Event Fetcher, using this client's configured url and token. Does
+   * NOT require connect(). Resolves to null when discovery is unsupported (a
+   * plain Event Bridge server or an older fetcher) — see {@link fetchInfo}.
+   * @param signal Optional AbortSignal to cancel the request.
+   */
+  public getInfo(signal?: AbortSignal): Promise<FetcherInfo | null> {
+    return fetchInfo({ url: this.options.url, token: this.options.token, signal })
+  }
+
+  /**
+   * Send an event to the bridge
+   * @param event The event to send
+   */
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/sdk && bun test -t getInfo`
+Expected: PASS — 1 test passes, 0 fail.
+
+- [ ] **Step 5: Verify types and the full suite**
+
+Run:
+```bash
+cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts && bun test
+```
+Expected: tsc — no output, exit 0; `bun test` — all tests pass (the pre-existing 5 + 13 fetchInfo + 1 getInfo = 19), 0 fail. (Full run takes ~30s due to the reconnection test.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/index.ts packages/sdk/index.test.ts
+git commit -m "feat(sdk): add client.getInfo() delegating to fetchInfo"
+```
+
+---
+
+## Task 3: Docs — README + example
+
+**Files:**
+- Modify: `packages/sdk/README.md`
+- Modify: `packages/sdk/example.ts`
+
+- [ ] **Step 1: Add `getInfo` to the README method list**
+
+In `packages/sdk/README.md`, find:
+
+```markdown
+- `getClientId()`: Get the client ID assigned by the bridge.
+- `send(event)`: Send an event to the bridge.
+```
+
+Replace with:
+
+```markdown
+- `getClientId()`: Get the client ID assigned by the bridge.
+- `getInfo(signal?)`: Fetch `/info` (configured rooms + instance metadata) from a LAPLACE Event Fetcher, using the client's url/token. No active connection required. Resolves to `null` when discovery is unsupported.
+- `send(event)`: Send an event to the bridge.
+```
+
+- [ ] **Step 2: Add a "Room Discovery" section to the README**
+
+In `packages/sdk/README.md`, find the start of the type-inference section:
+
+```markdown
+## Type Inference
+```
+
+Replace with (new section inserted before it):
+
+```markdown
+## Room Discovery
+
+When the server is a [LAPLACE Event Fetcher](https://chat.laplace.live) in bridge mode, it exposes a `/info` HTTP endpoint listing the configured rooms. The SDK can fetch it without an active WebSocket connection — useful for letting users pick which rooms to receive.
+
+Use the `client.getInfo()` method (reuses the client's `url`/`token`):
+
+```typescript
+const client = new LaplaceEventBridgeClient({ url: 'ws://localhost:9696', token })
+
+const info = await client.getInfo()
+if (info) {
+  console.log(`Fetcher v${info.version} exposes ${info.rooms.length} room(s)`)
+  for (const room of info.rooms) {
+    console.log(`${room.roomId}: ${room.username ?? 'unknown'}`)
+  }
+} else {
+  // Plain Event Bridge server or an older fetcher — fall back to manual entry.
+}
+```
+
+Or the standalone `fetchInfo()` function (no client object needed):
+
+```typescript
+import { fetchInfo } from '@laplace.live/event-bridge-sdk'
+
+const info = await fetchInfo({ url: 'ws://localhost:9696', token, signal })
+```
+
+Both resolve to `null` (never throw) when `/info` is unavailable — an old fetcher, a plain Event Bridge server, an aborted request, or any network/parse error — so callers can silently fall back to manual room entry. The returned shapes are `FetcherInfo` and `FetcherRoom`:
+
+```typescript
+interface FetcherRoom {
+  status: number // 0 = resolved, else an error code (e.g. 404)
+  uid: number
+  roomId: number // canonical room id; matches the `origin` field on events
+  shortRoomId: number
+  username: string | null
+}
+
+interface FetcherInfo {
+  version: string
+  uptime: string
+  connectedAt: number
+  websocketBridge: boolean
+  websocketClients: number
+  rooms: FetcherRoom[]
+}
+```
+
+## Type Inference
+```
+
+- [ ] **Step 3: Add a discovery snippet to the example**
+
+In `packages/sdk/example.ts`, find (lines 10-13):
+
+```ts
+})
+
+// Connect to the LAPLACE Event Bridge
+client
+```
+
+Replace with:
+
+```ts
+})
+
+// Discover which rooms the server exposes (LAPLACE Event Fetcher /info).
+// Resolves to null on a plain Event Bridge server or an older fetcher.
+client.getInfo().then(info => {
+  if (info) {
+    console.log(`Fetcher v${info.version} exposes ${info.rooms.length} room(s):`)
+    for (const room of info.rooms) {
+      console.log(`  - ${room.username ?? `Room ${room.roomId}`} (${room.roomId})`)
+    }
+  } else {
+    console.log('Room discovery not available; rooms must be entered manually.')
+  }
+})
+
+// Connect to the LAPLACE Event Bridge
+client
+```
+
+- [ ] **Step 4: Verify the example still typechecks**
+
+Run:
+```bash
+cd packages/sdk && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts example.ts
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/README.md packages/sdk/example.ts
+git commit -m "docs(sdk): document /info room discovery"
+```
+
+---
+
+## Task 4: Changeset
+
+**Files:**
+- Create: `.changeset/sdk-info-room-discovery.md`
+
+- [ ] **Step 1: Create the changeset**
+
+Create `.changeset/sdk-info-room-discovery.md` with:
+
+```markdown
+---
+"@laplace.live/event-bridge-sdk": minor
+---
+
+Add `/info` room discovery: a standalone `fetchInfo({ url, token })` and a `client.getInfo()` method that fetch the LAPLACE Event Fetcher `/info` endpoint and return the configured rooms plus instance metadata (`FetcherInfo` / `FetcherRoom`). Returns `null` when discovery is unsupported (a plain Event Bridge server or an older fetcher), so callers can fall back to manual entry. No active connection required.
+```
+
+- [ ] **Step 2: Verify the changeset is well-formed**
+
+Run: `bunx changeset status`
+Expected: reports `@laplace.live/event-bridge-sdk` to be bumped at **Minor**, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/sdk-info-room-discovery.md
+git commit -m "chore(sdk): add changeset for /info room discovery"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the full suite and type gate together:
+  ```bash
+  cd packages/sdk && bun test && bunx tsc --noEmit --skipLibCheck --strict --noUncheckedIndexedAccess --lib esnext,dom --module preserve --moduleResolution bundler --allowImportingTsExtensions --verbatimModuleSyntax index.ts example.ts index.test.ts
+  ```
+  Expected: `bun test` → all pass (19 tests), 0 fail; `tsc` → no output, exit 0.
+- [ ] `git log --oneline -4` shows the four commits (feat fetchInfo, feat getInfo, docs, changeset).
+
+---
+
+## Out of Scope / Follow-up (NOT part of this plan)
+
+- **`laplace-chat-overlay` migration** (separate repo): once this SDK ships, replace `src/lib/fetcher-info.ts`'s hand-rolled types/`buildInfoUrl`/fetch with `import { fetchInfo, type FetcherRoom } from '@laplace.live/event-bridge-sdk'`, and swap the `fetchAvailableRooms(...)` call in `src/components/settings-modal.tsx` for `fetchInfo({ url, token, signal })`. This is the real-world proof the DX gap is closed, tracked separately so this plan stays within the SDK repo.
+- **Server-side `rooms`/`uids` connection filtering** — deferred to a future DX pass (explicitly out of scope per the spec).

--- a/docs/superpowers/specs/2026-06-02-sdk-info-room-discovery-design.md
+++ b/docs/superpowers/specs/2026-06-02-sdk-info-room-discovery-design.md
@@ -1,0 +1,239 @@
+# SDK `/info` Room Discovery — Design
+
+- **Date:** 2026-06-02
+- **Status:** Approved (ready for implementation plan)
+- **Package:** `@laplace.live/event-bridge-sdk` (`packages/sdk`)
+- **Type:** Backward-compatible feature addition (minor version bump)
+
+## Context
+
+The LAPLACE Event Fetcher (LEF), when run in WebSocket bridge mode, exposes a
+`GET /info` HTTP endpoint that lists every configured room plus instance
+metadata. The plain Event Bridge server and older fetcher versions do **not**
+implement `/info`.
+
+A downstream consumer, `laplace-chat-overlay`, needed to show the user which
+rooms are available so they can pick which ones to allow. Because our SDK is
+**WebSocket-only and has no HTTP capability**, the overlay had to hand-roll the
+entire `/info` client in `src/lib/fetcher-info.ts`:
+
+1. **Redefined the wire types** — `FetcherRoom` and a `FetcherInfoResponse`
+   wrapper, by hand, mirroring LEF's schema.
+2. **Re-derived the HTTP URL from WS settings** — `buildInfoUrl()` converting
+   `ws://`/`wss://` → `http(s)://…/info`, with a comment noting it "mirrors the
+   URL handling in `useLaplaceClient`" (i.e. duplicated logic even within the
+   overlay).
+3. **Implemented fetch + auth + silent fallback** — `GET` with
+   `Authorization: Bearer <token>`, returning `FetcherRoom[]` or `null` on any
+   failure (old fetcher, plain Event Bridge server, abort, network/parse error).
+
+Every future consumer that wants room discovery would repeat all three steps.
+That is the developer-experience gap this design closes.
+
+### What LEF's `/info` returns
+
+```jsonc
+{
+  "success": true,
+  "status": 200,
+  "data": {
+    "version": "4.0.20",
+    "uptime": "2 hours ago",
+    "connectedAt": 1717200000000,
+    "websocketBridge": true,
+    "websocketClients": 3,
+    "rooms": [
+      { "status": 0,   "uid": 2132180406, "roomId": 25034104, "shortRoomId": 0, "username": "明前奶绿" },
+      { "status": 404, "uid": 0,          "roomId": 456117,   "shortRoomId": 0, "username": null }
+    ]
+  }
+}
+```
+
+- Auth: `Authorization: Bearer <token>` (also accepts a bare token); only
+  required when LEF has `AUTH_KEY` configured.
+- `Cache-Control: private, max-age=60` on success.
+- `status: 0` on a room means resolved; non-zero (e.g. `404`) means the room
+  could not be looked up.
+
+## Goals
+
+- Give the SDK a first-class, typed way to fetch `/info` so consumers stop
+  hand-rolling types, URL derivation, and fetch/fallback.
+- Work **without an active WebSocket connection** (discovery happens before/while
+  the user configures the connection).
+- Be a faithful drop-in for the overlay's existing behavior so the overlay can
+  delete its hand-rolled module.
+
+## Non-Goals
+
+- Server-side `rooms`/`uids` connection filtering (LEF supports it; deferred to a
+  future DX pass — explicitly out of scope here).
+- Exporting general-purpose URL utilities or any broader SDK refactor.
+- Changes to `@laplace.live/event-types`. The `/info` payload is a *bridge
+  protocol* shape, not a chat event, so the types live in the SDK.
+- Any change inside `laplace-event-fetcher` (LEF already ships `/info`).
+
+## Design
+
+All additions go in the single SDK module `packages/sdk/index.ts`. The package's
+`types` entry already points at `./index.ts`, so new exported types are available
+to consumers immediately.
+
+### 1. Exported types
+
+Placed alongside the other exported types (after `ConnectionOptions`). Names use
+the `Fetcher*` prefix for parity with the overlay and LEF terminology.
+
+```ts
+export interface FetcherRoom {
+  /** 0 when the room was resolved, otherwise an error code (e.g. 404). */
+  status: number
+  uid: number
+  /** Canonical room id. Matches the `origin` field on incoming events. */
+  roomId: number
+  shortRoomId: number
+  username: string | null
+}
+
+export interface FetcherInfo {
+  version: string
+  uptime: string
+  connectedAt: number
+  websocketBridge: boolean
+  websocketClients: number
+  rooms: FetcherRoom[]
+}
+```
+
+`FetcherInfo` is the unwrapped `data` payload — the shape consumers actually
+care about. The `{ success, status, data }` envelope is an **internal**
+interface (`FetcherInfoResponse`), not exported.
+
+### 2. `FetchInfoOptions` + `fetchInfo()` (standalone, exported)
+
+```ts
+export interface FetchInfoOptions {
+  /** Same ws/wss URL style as ConnectionOptions.url, e.g. 'ws://localhost:9696'. */
+  url: string
+  /** Auth token; sent as `Authorization: Bearer <token>` when present. */
+  token?: string
+  /** Optional AbortSignal for cancellation (e.g. a modal closing). */
+  signal?: AbortSignal
+}
+
+/**
+ * Fetch instance/room info from a LAPLACE Event Fetcher `/info` endpoint.
+ * Returns `null` (never throws) when info cannot be determined: an old fetcher
+ * without `/info`, a plain Event Bridge server, an aborted request, or any
+ * network/HTTP/parse error. Callers should treat `null` as "not supported" and
+ * fall back to manual entry.
+ */
+export async function fetchInfo(options: FetchInfoOptions): Promise<FetcherInfo | null>
+```
+
+Behavior:
+
+- Return `null` immediately if `url` is empty.
+- Build the request URL as `wsToHttp(url) + '/info'`.
+- Set `Authorization: Bearer <token>` only when `token` is non-empty.
+- `GET` with the provided `signal`.
+- Return `null` if the response is not OK, if `success` is not `true`, or if
+  `data.rooms` is not an array; otherwise return `data` as `FetcherInfo`.
+- Wrap everything in `try/catch` and return `null` on any thrown error.
+
+`fetch` and `AbortSignal` are standard globals in all target runtimes (modern
+browsers, Bun, Node ≥ 18); no polyfill or new dependency is required.
+
+### 3. `wsToHttp()` (internal helper)
+
+A private module-level function (not exported — keeps the surface minimal per the
+focused scope):
+
+```ts
+function wsToHttp(url: string): string
+```
+
+- `wss://host[:port]` → `https://host[:port]`
+- `ws://host[:port]` → `http://host[:port]`
+- `http://…` / `https://…` → unchanged
+- bare host (no scheme) → `https://` if it contains `:443`, else `http://`
+- strip any trailing slash(es) before the caller appends `/info`
+
+This becomes the SDK's single source of truth for ws→http derivation, replacing
+the overlay's `buildInfoUrl`.
+
+### 4. `client.getInfo()` (instance method, thin delegate)
+
+Added to `LaplaceEventBridgeClient` near the other status accessors
+(`getConnectionState`, `getClientId`). Requires **no** prior `connect()`:
+
+```ts
+/**
+ * Fetch `/info` (rooms + instance metadata) using this client's configured
+ * url/token. Returns null when unsupported/unreachable (see fetchInfo).
+ */
+getInfo(signal?: AbortSignal): Promise<FetcherInfo | null> {
+  return fetchInfo({ url: this.options.url, token: this.options.token, signal })
+}
+```
+
+### Failure semantics (decided)
+
+Return `null`, never throw — covering old/unsupported servers, network errors,
+non-OK status (incl. 403), aborts, and bad JSON uniformly. This is the overlay's
+proven contract and the lowest-friction drop-in. Distinguishing failure causes
+(e.g. surfacing 403) is intentionally not done here.
+
+## Files changed (SDK)
+
+| File | Change |
+| --- | --- |
+| `packages/sdk/index.ts` | Add `FetcherRoom`, `FetcherInfo`, `FetchInfoOptions` (exported); `FetcherInfoResponse` + `wsToHttp` (internal); `fetchInfo()` (exported); `getInfo()` method. |
+| `packages/sdk/index.test.ts` | Add tests (below). |
+| `packages/sdk/README.md` | Add a "Room discovery" section documenting `fetchInfo` / `getInfo`, the `null` = unsupported contract, and the `FetcherInfo`/`FetcherRoom` shapes. |
+| `packages/sdk/example.ts` | Add a discovery snippet: call `fetchInfo`/`getInfo` before `connect()` and log available rooms. |
+| `packages/sdk/package.json` | Version bump to `1.1.0` via changeset (not edited by hand). |
+| `.changeset/*.md` | New `minor` changeset for `@laplace.live/event-bridge-sdk`. |
+
+## Testing
+
+Bun tests in `packages/sdk/index.test.ts`, mocking the global `fetch`:
+
+- **URL derivation** (observed via the URL passed to the mocked `fetch`):
+  - `ws://localhost:9696` → `http://localhost:9696/info`
+  - `wss://event-fetcher.laplace.cn` → `https://event-fetcher.laplace.cn/info`
+  - port preserved; trailing slash on the base URL does not double up.
+- **Auth header:** `Authorization: Bearer <token>` present when a token is given;
+  absent when token is empty/omitted.
+- **Success:** valid envelope → returns `data` (`FetcherInfo`) with `rooms`.
+- **Null fallbacks (each returns `null`, no throw):** empty `url`; `res.ok ===
+  false` (e.g. 403/404); `success !== true`; `data.rooms` not an array; `fetch`
+  rejects (network error); `res.json()` rejects (bad JSON); aborted signal.
+- **`getInfo()` delegation:** a client constructed with `{ url, token }` (no
+  `connect()`) calls `fetch` with the derived URL and bearer header.
+
+## Versioning
+
+Backward-compatible additions only → **minor** bump `1.0.24 → 1.1.0` via a new
+changeset (the repo's release flow handles the actual version/publish).
+
+## Validating consumer change (separate repo — follow-up, NOT in the SDK plan)
+
+After the SDK ships, `laplace-chat-overlay` proves the gap is closed:
+
+- `src/lib/fetcher-info.ts` collapses to
+  `import { fetchInfo, type FetcherRoom } from '@laplace.live/event-bridge-sdk'`
+  (or is deleted, with call sites importing the SDK directly); the hand-rolled
+  types, `buildInfoUrl`, and fetch/fallback are removed (~90 lines).
+- `src/components/settings-modal.tsx` swaps `fetchAvailableRooms(host, port,
+  password, signal)` for `fetchInfo({ url, token, signal })` (reading
+  `info?.rooms`), building `url` the same way `useLaplaceClient` already does.
+
+This is tracked as a follow-up so the SDK implementation plan stays scoped to
+this repository.
+
+## Open questions
+
+None — scope, API shape (standalone `fetchInfo` + delegating `getInfo`),
+naming (`Fetcher*`), and failure semantics (`null`, never throw) are all decided.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -112,7 +112,57 @@ enum ConnectionState {
 - `isConnectedToBridge()`: Check if the client is connected to the bridge. (Deprecated: use `getConnectionState()` instead)
 - `getConnectionState()`: Get the current connection state.
 - `getClientId()`: Get the client ID assigned by the bridge.
+- `getInfo(signal?)`: Fetch `/info` (configured rooms + instance metadata) from a LAPLACE Event Fetcher, using the client's url/token. No active connection required. Resolves to `null` when discovery is unsupported.
 - `send(event)`: Send an event to the bridge.
+
+## Room Discovery
+
+When the server is a [LAPLACE Event Fetcher](https://chat.laplace.live) in bridge mode, it exposes a `/info` HTTP endpoint listing the configured rooms. The SDK can fetch it without an active WebSocket connection — useful for letting users pick which rooms to receive.
+
+Use the `client.getInfo()` method (reuses the client's `url`/`token`):
+
+```typescript
+const client = new LaplaceEventBridgeClient({ url: 'ws://localhost:9696', token })
+
+const info = await client.getInfo()
+if (info) {
+  console.log(`Fetcher v${info.version} exposes ${info.rooms.length} room(s)`)
+  for (const room of info.rooms) {
+    console.log(`${room.roomId}: ${room.username ?? 'unknown'}`)
+  }
+} else {
+  // Plain Event Bridge server or an older fetcher — fall back to manual entry.
+}
+```
+
+Or the standalone `fetchInfo()` function (no client object needed):
+
+```typescript
+import { fetchInfo } from '@laplace.live/event-bridge-sdk'
+
+const info = await fetchInfo({ url: 'ws://localhost:9696', token, signal })
+```
+
+Both resolve to `null` (never throw) when `/info` is unavailable — an old fetcher, a plain Event Bridge server, an aborted request, or any network/parse error — so callers can silently fall back to manual room entry. The returned shapes are `FetcherInfo` and `FetcherRoom`:
+
+```typescript
+interface FetcherRoom {
+  status: number // 0 = resolved, else an error code (e.g. 404)
+  uid: number
+  roomId: number // canonical room id; matches the `origin` field on events
+  shortRoomId: number
+  username: string | null
+}
+
+interface FetcherInfo {
+  version: string
+  uptime: string
+  connectedAt: number
+  websocketBridge: boolean
+  websocketClients: number
+  rooms: FetcherRoom[]
+}
+```
 
 ## Type Inference
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -143,25 +143,12 @@ import { fetchInfo } from '@laplace.live/event-bridge-sdk'
 const info = await fetchInfo({ url: 'ws://localhost:9696', token, signal })
 ```
 
-Both resolve to `null` (never throw) when `/info` is unavailable — an old fetcher, a plain Event Bridge server, an aborted request, or any network/parse error — so callers can silently fall back to manual room entry. The returned shapes are `FetcherInfo` and `FetcherRoom`:
+Both resolve to `null` (never throw) when `/info` is unavailable — an old fetcher, a plain Event Bridge server, an aborted request, or any network/parse error — so callers can silently fall back to manual room entry.
+
+The returned shapes are `FetcherInfo` and `FetcherRoom`. Both are exported from the SDK, so import them directly rather than redeclaring your own:
 
 ```typescript
-interface FetcherRoom {
-  status: number // 0 = resolved, else an error code (e.g. 404)
-  uid: number
-  roomId: number // canonical room id; matches the `origin` field on events
-  shortRoomId: number
-  username: string | null
-}
-
-interface FetcherInfo {
-  version: string
-  uptime: string
-  connectedAt: number
-  websocketBridge: boolean
-  websocketClients: number
-  rooms: FetcherRoom[]
-}
+import type { FetcherInfo, FetcherRoom } from '@laplace.live/event-bridge-sdk'
 ```
 
 ## Type Inference

--- a/packages/sdk/example.ts
+++ b/packages/sdk/example.ts
@@ -9,6 +9,19 @@ const client = new LaplaceEventBridgeClient({
   maxReconnectAttempts: 5,
 })
 
+// Discover which rooms the server exposes (LAPLACE Event Fetcher /info).
+// Resolves to null on a plain Event Bridge server or an older fetcher.
+client.getInfo().then(info => {
+  if (info) {
+    console.log(`Fetcher v${info.version} exposes ${info.rooms.length} room(s):`)
+    for (const room of info.rooms) {
+      console.log(`  - ${room.username ?? `Room ${room.roomId}`} (${room.roomId})`)
+    }
+  } else {
+    console.log('Room discovery not available; rooms must be entered manually.')
+  }
+})
+
 // Connect to the LAPLACE Event Bridge
 client
   .connect()

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -6,7 +6,7 @@ import { ConnectionState, fetchInfo, LaplaceEventBridgeClient } from './index'
 const isAIAgent = process.env.CLAUDECODE === '1' || process.env.REPL_ID === '1' || process.env.AGENT === '1'
 
 // Helper to conditionally log based on AI agent environment
-const log = (...args: any[]) => {
+const log = (...args: unknown[]) => {
   if (!isAIAgent) {
     console.log(...args)
   }
@@ -74,10 +74,10 @@ describe('LaplaceEventBridgeClient', () => {
           originalLog(...args)
           const message = args.join(' ')
           const match = message.match(/Attempting to reconnect \((\d+)\/\d+\) in (\d+)ms/)
-          if (match) {
+          if (match?.[1] && match[2]) {
             reconnectTimings.push({
-              attempt: parseInt(match[1]!, 10),
-              scheduledDelay: parseInt(match[2]!, 10),
+              attempt: parseInt(match[1], 10),
+              scheduledDelay: parseInt(match[2], 10),
             })
           }
         })
@@ -227,6 +227,31 @@ describe('LaplaceEventBridgeClient', () => {
   })
 })
 
+// `fetchInfo` only ever sends plain-object headers, so narrow `init` to match.
+// This keeps call-arg reads (`headers.authorization`) cast-free.
+type FetchInit = Omit<RequestInit, 'headers'> & { headers?: Record<string, string> }
+type FetchImpl = (url: string, init?: FetchInit) => Promise<Response>
+
+// Install a typed fake `globalThis.fetch` and return the spy for call assertions.
+// The single unavoidable `as unknown as typeof fetch` lives here, not at every
+// call site. The default impl throws so tests that should never fetch fail loudly.
+const mockFetch = (
+  impl: FetchImpl = async () => {
+    throw new Error('fetch was not expected to be called')
+  }
+) => {
+  const spy = jest.fn(impl)
+  globalThis.fetch = spy as unknown as typeof fetch
+  return spy
+}
+
+// Build a 200 `/info` envelope wrapping `data`.
+const okResponse = (data: unknown) =>
+  new Response(JSON.stringify({ success: true, status: 200, data }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
 describe('fetchInfo', () => {
   const realFetch = globalThis.fetch
 
@@ -243,93 +268,77 @@ describe('fetchInfo', () => {
     ],
   }
 
-  const okResponse = (data: unknown) =>
-    new Response(JSON.stringify({ success: true, status: 200, data }), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    })
-
   afterEach(() => {
     globalThis.fetch = realFetch
   })
 
   test('derives an http URL from a ws URL and appends /info', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'ws://localhost:9696' })
 
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+    expect(spy.mock.calls[0]?.[0]).toBe('http://localhost:9696/info')
   })
 
   test('derives an https URL from a wss URL', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'wss://event-fetcher.laplace.cn' })
 
-    expect(spy.mock.calls[0]![0]).toBe('https://event-fetcher.laplace.cn/info')
+    expect(spy.mock.calls[0]?.[0]).toBe('https://event-fetcher.laplace.cn/info')
   })
 
   test('does not double up a trailing slash on the base URL', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'ws://localhost:9696/' })
 
-    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+    expect(spy.mock.calls[0]?.[0]).toBe('http://localhost:9696/info')
   })
 
   test('passes through an http URL unchanged', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'http://localhost:9696' })
 
-    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+    expect(spy.mock.calls[0]?.[0]).toBe('http://localhost:9696/info')
   })
 
   test('passes through an https URL unchanged', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'https://event-fetcher.laplace.cn' })
 
-    expect(spy.mock.calls[0]![0]).toBe('https://event-fetcher.laplace.cn/info')
+    expect(spy.mock.calls[0]?.[0]).toBe('https://event-fetcher.laplace.cn/info')
   })
 
   test('preserves a sub-path for reverse-proxied fetchers', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'wss://example.com/lef/' })
 
-    expect(spy.mock.calls[0]![0]).toBe('https://example.com/lef/info')
+    expect(spy.mock.calls[0]?.[0]).toBe('https://example.com/lef/info')
   })
 
   test('sends an Authorization bearer header when a token is provided', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'ws://localhost:9696', token: 'secret' })
 
-    const init = spy.mock.calls[0]![1] as RequestInit
-    expect((init.headers as Record<string, string>).authorization).toBe('Bearer secret')
+    expect(spy.mock.calls[0]?.[1]?.headers?.authorization).toBe('Bearer secret')
   })
 
   test('omits the Authorization header when no token is provided', async () => {
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(sampleInfo))
 
     await fetchInfo({ url: 'ws://localhost:9696' })
 
-    const init = spy.mock.calls[0]![1] as RequestInit
-    expect((init.headers as Record<string, string>).authorization).toBeUndefined()
+    expect(spy.mock.calls[0]?.[1]?.headers?.authorization).toBeUndefined()
   })
 
   test('returns the data payload on success', async () => {
-    globalThis.fetch = (async () => okResponse(sampleInfo)) as unknown as typeof fetch
+    mockFetch(async () => okResponse(sampleInfo))
 
     const info = await fetchInfo({ url: 'ws://localhost:9696' })
 
@@ -338,8 +347,7 @@ describe('fetchInfo', () => {
   })
 
   test('returns null without fetching when url is empty', async () => {
-    const spy = jest.fn()
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch()
 
     const info = await fetchInfo({ url: '' })
 
@@ -348,42 +356,42 @@ describe('fetchInfo', () => {
   })
 
   test('returns null on a non-ok response (e.g. 403)', async () => {
-    globalThis.fetch = (async () => new Response('', { status: 403 })) as unknown as typeof fetch
+    mockFetch(async () => new Response('', { status: 403 }))
     expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
   })
 
   test('returns null when the envelope success flag is false', async () => {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ success: false, status: 403, message: 'Unauthorized' }), {
-        status: 200,
-      })) as unknown as typeof fetch
+    mockFetch(
+      async () =>
+        new Response(JSON.stringify({ success: false, status: 403, message: 'Unauthorized' }), { status: 200 })
+    )
     expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
   })
 
   test('returns null when rooms is not an array', async () => {
-    globalThis.fetch = (async () => okResponse({ ...sampleInfo, rooms: undefined })) as unknown as typeof fetch
+    mockFetch(async () => okResponse({ ...sampleInfo, rooms: undefined }))
     expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
   })
 
   test('returns null on a network error', async () => {
-    globalThis.fetch = (async () => {
+    mockFetch(async () => {
       throw new Error('network down')
-    }) as unknown as typeof fetch
+    })
     expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
   })
 
   test('returns null on invalid JSON', async () => {
-    globalThis.fetch = (async () => new Response('not json', { status: 200 })) as unknown as typeof fetch
+    mockFetch(async () => new Response('not json', { status: 200 }))
     expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
   })
 
   test('returns null when the signal is already aborted', async () => {
-    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    mockFetch(async (_url, init) => {
       if (init?.signal?.aborted) {
         throw new DOMException('Aborted', 'AbortError')
       }
       return okResponse(sampleInfo)
-    }) as unknown as typeof fetch
+    })
 
     const controller = new AbortController()
     controller.abort()
@@ -408,18 +416,13 @@ describe('client.getInfo', () => {
       websocketClients: 0,
       rooms: [],
     }
-    const spy = jest.fn(
-      async (_url: string, _init?: RequestInit) =>
-        new Response(JSON.stringify({ success: true, status: 200, data }), { status: 200 })
-    )
-    globalThis.fetch = spy as unknown as typeof fetch
+    const spy = mockFetch(async () => okResponse(data))
 
     const client = new LaplaceEventBridgeClient({ url: 'wss://example.com', token: 'tok' })
     const info = await client.getInfo()
 
-    expect(spy.mock.calls[0]![0]).toBe('https://example.com/info')
-    const init = spy.mock.calls[0]![1] as RequestInit
-    expect((init.headers as Record<string, string>).authorization).toBe('Bearer tok')
+    expect(spy.mock.calls[0]?.[0]).toBe('https://example.com/info')
+    expect(spy.mock.calls[0]?.[1]?.headers?.authorization).toBe('Bearer tok')
     expect(info?.rooms).toEqual([])
   })
 })

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test'
 
-import { ConnectionState, LaplaceEventBridgeClient } from './index'
+import { ConnectionState, fetchInfo, LaplaceEventBridgeClient } from './index'
 
 // Detect if running in AI agent environment for cleaner output
 const isAIAgent = process.env.CLAUDECODE === '1' || process.env.REPL_ID === '1' || process.env.AGENT === '1'
@@ -224,5 +224,161 @@ describe('LaplaceEventBridgeClient', () => {
       // indicates that ping monitoring was properly cleaned up
       client.disconnect()
     })
+  })
+})
+
+describe('fetchInfo', () => {
+  const realFetch = globalThis.fetch
+
+  // Minimal valid `/info` payload — the `data` object fetchInfo returns.
+  const sampleInfo = {
+    version: '4.0.20',
+    uptime: '2 hours ago',
+    connectedAt: 1717200000000,
+    websocketBridge: true,
+    websocketClients: 3,
+    rooms: [
+      { status: 0, uid: 2132180406, roomId: 25034104, shortRoomId: 0, username: '明前奶绿' },
+      { status: 404, uid: 0, roomId: 456117, shortRoomId: 0, username: null },
+    ],
+  }
+
+  const okResponse = (data: unknown) =>
+    new Response(JSON.stringify({ success: true, status: 200, data }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  test('derives an http URL from a ws URL and appends /info', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696' })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+  })
+
+  test('derives an https URL from a wss URL', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'wss://event-fetcher.laplace.cn' })
+
+    expect(spy.mock.calls[0]![0]).toBe('https://event-fetcher.laplace.cn/info')
+  })
+
+  test('does not double up a trailing slash on the base URL', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696/' })
+
+    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+  })
+
+  test('passes through an http URL unchanged', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'http://localhost:9696' })
+
+    expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
+  })
+
+  test('preserves a sub-path for reverse-proxied fetchers', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'wss://example.com/lef/' })
+
+    expect(spy.mock.calls[0]![0]).toBe('https://example.com/lef/info')
+  })
+
+  test('sends an Authorization bearer header when a token is provided', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696', token: 'secret' })
+
+    const init = spy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer secret')
+  })
+
+  test('omits the Authorization header when no token is provided', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'ws://localhost:9696' })
+
+    const init = spy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>).authorization).toBeUndefined()
+  })
+
+  test('returns the data payload on success', async () => {
+    globalThis.fetch = (async () => okResponse(sampleInfo)) as unknown as typeof fetch
+
+    const info = await fetchInfo({ url: 'ws://localhost:9696' })
+
+    expect(info).toEqual(sampleInfo)
+    expect(info?.rooms).toHaveLength(2)
+  })
+
+  test('returns null without fetching when url is empty', async () => {
+    const spy = jest.fn()
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    const info = await fetchInfo({ url: '' })
+
+    expect(info).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('returns null on a non-ok response (e.g. 403)', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 403 })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null when the envelope success flag is false', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ success: false, status: 403, message: 'Unauthorized' }), {
+        status: 200,
+      })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null when rooms is not an array', async () => {
+    globalThis.fetch = (async () => okResponse({ ...sampleInfo, rooms: undefined })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null on a network error', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null on invalid JSON', async () => {
+    globalThis.fetch = (async () => new Response('not json', { status: 200 })) as unknown as typeof fetch
+    expect(await fetchInfo({ url: 'ws://localhost:9696' })).toBeNull()
+  })
+
+  test('returns null when the signal is already aborted', async () => {
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException('Aborted', 'AbortError')
+      }
+      return okResponse(sampleInfo)
+    }) as unknown as typeof fetch
+
+    const controller = new AbortController()
+    controller.abort()
+
+    expect(await fetchInfo({ url: 'ws://localhost:9696', signal: controller.signal })).toBeNull()
   })
 })

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -382,3 +382,34 @@ describe('fetchInfo', () => {
     expect(await fetchInfo({ url: 'ws://localhost:9696', signal: controller.signal })).toBeNull()
   })
 })
+
+describe('client.getInfo', () => {
+  const realFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  test('fetches /info using the client url and token without connecting', async () => {
+    const data = {
+      version: '4.0.20',
+      uptime: '',
+      connectedAt: 0,
+      websocketBridge: true,
+      websocketClients: 0,
+      rooms: [],
+    }
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) =>
+      new Response(JSON.stringify({ success: true, status: 200, data }), { status: 200 })
+    )
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    const client = new LaplaceEventBridgeClient({ url: 'wss://example.com', token: 'tok' })
+    const info = await client.getInfo()
+
+    expect(spy.mock.calls[0]![0]).toBe('https://example.com/info')
+    const init = spy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer tok')
+    expect(info?.rooms).toEqual([])
+  })
+})

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -290,6 +290,15 @@ describe('fetchInfo', () => {
     expect(spy.mock.calls[0]![0]).toBe('http://localhost:9696/info')
   })
 
+  test('passes through an https URL unchanged', async () => {
+    const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
+    globalThis.fetch = spy as unknown as typeof fetch
+
+    await fetchInfo({ url: 'https://event-fetcher.laplace.cn' })
+
+    expect(spy.mock.calls[0]![0]).toBe('https://event-fetcher.laplace.cn/info')
+  })
+
   test('preserves a sub-path for reverse-proxied fetchers', async () => {
     const spy = jest.fn(async (_url: string, _init?: RequestInit) => okResponse(sampleInfo))
     globalThis.fetch = spy as unknown as typeof fetch
@@ -399,8 +408,9 @@ describe('client.getInfo', () => {
       websocketClients: 0,
       rooms: [],
     }
-    const spy = jest.fn(async (_url: string, _init?: RequestInit) =>
-      new Response(JSON.stringify({ success: true, status: 200, data }), { status: 200 })
+    const spy = jest.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(JSON.stringify({ success: true, status: 200, data }), { status: 200 })
     )
     globalThis.fetch = spy as unknown as typeof fetch
 

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -381,6 +381,17 @@ export class LaplaceEventBridgeClient {
   }
 
   /**
+   * Fetch `/info` (configured rooms + instance metadata) from the connected
+   * LAPLACE Event Fetcher, using this client's configured url and token. Does
+   * NOT require connect(). Resolves to null when discovery is unsupported (a
+   * plain Event Bridge server or an older fetcher) — see {@link fetchInfo}.
+   * @param signal Optional AbortSignal to cancel the request.
+   */
+  public getInfo(signal?: AbortSignal): Promise<FetcherInfo | null> {
+    return fetchInfo({ url: this.options.url, token: this.options.token, signal })
+  }
+
+  /**
    * Send an event to the bridge
    * @param event The event to send
    */

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -63,6 +63,41 @@ export interface ConnectionOptions {
   pingTimeout?: number
 }
 
+export interface FetcherRoom {
+  /** 0 when the room was resolved, otherwise an error code (e.g. 404). */
+  status: number
+  uid: number
+  /** Canonical room id. Matches the `origin` field on incoming events. */
+  roomId: number
+  shortRoomId: number
+  username: string | null
+}
+
+export interface FetcherInfo {
+  version: string
+  uptime: string
+  connectedAt: number
+  websocketBridge: boolean
+  websocketClients: number
+  rooms: FetcherRoom[]
+}
+
+export interface FetchInfoOptions {
+  /** Same ws/wss URL style as ConnectionOptions.url, e.g. 'ws://localhost:9696'. */
+  url: string
+  /** Auth token; sent as `Authorization: Bearer <token>` when present. */
+  token?: string
+  /** Optional AbortSignal for cancellation (e.g. a modal closing). */
+  signal?: AbortSignal
+}
+
+/** The `/info` response envelope. Internal — callers receive the unwrapped `data` (FetcherInfo). */
+interface FetcherInfoResponse {
+  success: boolean
+  status: number
+  data: FetcherInfo
+}
+
 export class LaplaceEventBridgeClient {
   private ws: WebSocket | null = null
   private eventHandlers = new Map<string, EventHandler<any>[]>()
@@ -465,5 +500,74 @@ export class LaplaceEventBridgeClient {
       clearInterval(this.pingMonitorTimer)
       this.pingMonitorTimer = null
     }
+  }
+}
+
+/**
+ * Convert a ws/wss URL to the http/https URL of the same endpoint so we can
+ * reach HTTP routes like `/info`. Swaps the scheme (wss→https, ws→http) and
+ * preserves host, port, and any path (so a fetcher reverse-proxied under a
+ * sub-path still resolves). http(s) URLs pass through; a bare host with no
+ * scheme defaults to http, or https when it targets port 443. Any trailing
+ * slash is stripped so callers can append a path.
+ */
+function wsToHttp(url: string): string {
+  let httpUrl: string
+  if (url.startsWith('wss://')) {
+    httpUrl = `https://${url.slice('wss://'.length)}`
+  } else if (url.startsWith('ws://')) {
+    httpUrl = `http://${url.slice('ws://'.length)}`
+  } else if (url.startsWith('http://') || url.startsWith('https://')) {
+    httpUrl = url
+  } else {
+    httpUrl = `${/:443(\/|$)/.test(url) ? 'https' : 'http'}://${url}`
+  }
+  return httpUrl.replace(/\/+$/, '')
+}
+
+/**
+ * Fetch instance/room info from a LAPLACE Event Fetcher `/info` endpoint.
+ *
+ * Returns `null` (never throws) whenever the info cannot be determined: an old
+ * fetcher without `/info`, a plain Event Bridge server, an aborted request, or
+ * any network/HTTP/parse error. Callers should treat `null` as "not supported"
+ * and fall back to manual entry.
+ *
+ * @example
+ * const info = await fetchInfo({ url: 'ws://localhost:9696', token })
+ * info?.rooms.forEach(room => console.log(room.roomId, room.username))
+ */
+export async function fetchInfo(options: FetchInfoOptions): Promise<FetcherInfo | null> {
+  const { url, token, signal } = options
+  if (!url) {
+    return null
+  }
+
+  try {
+    const headers: Record<string, string> = {}
+    if (token) {
+      headers.authorization = `Bearer ${token}`
+    }
+
+    const response = await fetch(`${wsToHttp(url)}/info`, {
+      method: 'GET',
+      headers,
+      signal,
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const json = (await response.json()) as FetcherInfoResponse
+    if (!json?.success || !Array.isArray(json?.data?.rooms)) {
+      return null
+    }
+
+    return json.data
+  } catch {
+    // Silent fallback: old fetcher without /info, plain Event Bridge server,
+    // aborted request, network failure, or a non-JSON response.
+    return null
   }
 }

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -533,7 +533,14 @@ function wsToHttp(url: string): string {
   } else {
     httpUrl = `${/:443(\/|$)/.test(url) ? 'https' : 'http'}://${url}`
   }
-  return httpUrl.replace(/\/+$/, '')
+  // Strip trailing slashes so callers can append a path. A linear scan rather
+  // than `/\/+$/` — that pattern backtracks polynomially on a long slash run
+  // (a user-entered fetcher URL is uncontrolled input) and trips ReDoS scanners.
+  let end = httpUrl.length
+  while (end > 0 && httpUrl.charCodeAt(end - 1) === 47 /* '/' */) {
+    end--
+  }
+  return httpUrl.slice(0, end)
 }
 
 /**

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "Preserve",
     "moduleDetection": "force",
     "allowJs": true,
+    "types": ["bun"],
 
     // Bundler mode
     "moduleResolution": "bundler",


### PR DESCRIPTION
Add first-class, typed /info room discovery to the event-bridge SDK so consumers stop hand-rolling the types, ws->http URL derivation, and fetch/fallback (as laplace-chat-overlay currently does). Standalone fetchInfo() + delegating client.getInfo(); returns null on any failure; no connection required.